### PR TITLE
canActivate callback was added

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Option Name   | Required | Type   | Default | Description
 `beforeAll`   | false    | Function | undefined    | before all middleware function to run before all routes (after validation occurs)
 `afterAll`    | false    | Function | undefined    | after all middleware function to run after all routes
 `onError`     | false    | Function | undefined    | onError callback, called in case of errors while handle endpoint
+`canActivate` | false    | Function | undefined    | middleware function to run before all routes (and before validation occurs) in case if there are conditions to determine whether a given request will be handled by the route handler or not 
 `globalLogger`| false    | boolean| false   | will apply the logger function to the global scope (`global.logger`)
 
 2. Create endpoint file with matching methods and requirements

--- a/src/apigateway/router.js
+++ b/src/apigateway/router.js
@@ -17,6 +17,7 @@ class Router {
         this._basePath = params.basePath;
         this._handlerPath = params.handlerPath;
         this._onError = params.onError;
+        this._canActivate = params.canActivate;
         this._errors = new ResponseClient();
         this._logger = new Logger();
         this._schemaPath = params.schemaPath;
@@ -54,6 +55,9 @@ class Router {
         const requestValidator = new RequestValidator(request, response, schema);
         const responseValidator = new ResponseValidator(request, response, schema);
 
+        if (!response.hasErrors && this._canActivate && typeof this._canActivate === 'function') {
+            await this._canActivate(request, response);
+        }
         if (!response.hasErrors && endpoint.requirements && endpoint.requirements[method]) {
             await requestValidator.isValid(endpoint.requirements[method]);
         }

--- a/test/apigateway/router.test.js
+++ b/test/apigateway/router.test.js
@@ -175,5 +175,36 @@ describe('Test Router', () => {
             assert.deepEqual(spyFn.getCall(0).args[2], error);
             assert.equal(spyFn.getCall(0).args[1].code, response.statusCode);
         });
+        it('should call canActivate callback if canActivate exist', async () => {
+            const event = await mockData.getApiGateWayRoute('', '', 'PATCH');
+            const spyFn = sinon.fake();
+
+            this.router = new Router({
+                event,
+                basePath: 'unittest/v1',
+                handlerPath: 'test/apigateway/',
+                schemaPath: 'test/openapi.yml',
+                canActivate: spyFn
+            });
+            const response = await this.router.route();
+            assert.deepEqual(spyFn.callCount, 1);
+        });
+        it('should stop route handling if canActivate throws an error', async () => {
+            const event = await mockData.getApiGateWayRoute('', '', 'PATCH');
+            const spyFn = sinon.fake();
+
+            this.router = new Router({
+                event,
+                basePath: 'unittest/v1',
+                handlerPath: 'test/apigateway/',
+                schemaPath: 'test/openapi.yml',
+                canActivate: () => {
+                    throw new Error();
+                },
+                beforeAll: spyFn
+            });
+            const response = await this.router.route();
+            assert.deepEqual(spyFn.callCount, 0);
+        });
     });
 });


### PR DESCRIPTION
Sometimes there are conditions in case of non-fulfillment of which request processing should be terminated, for example, the absence of an authorization token in the request. 

            this.router = new Router({
              
                canActivate: (request) => {
                    const protectedRoutes = ['invites'];
                    if (protectedRoutes.includes(request.path.proxy) && !request.headers['authorization']) {
                        throw new UnauthorizedError('Token is required');
                    }
                },
            });
