### PR TITLE
use this._error instead of response in handleError calling

### DIFF
--- a/src/apigateway/router.js
+++ b/src/apigateway/router.js
@@ -168,7 +168,7 @@ class Router {
             const endpointFile = await this._getEndpoint();
             return (await this._runEndpoint({endpointFile, request, response})).response;
         } catch (error) {
-            await this._handleError(request, response, error);
+            await this._handleError(request, this._errors, error);
             return this._errors.response;
         }
     }

--- a/test/apigateway/router.test.js
+++ b/test/apigateway/router.test.js
@@ -175,5 +175,25 @@ describe('Test Router', () => {
             assert.deepEqual(spyFn.getCall(0).args[2], error);
             assert.equal(spyFn.getCall(0).args[1].code, response.statusCode);
         });
+        it('should return status code that was set in onError callback', async () => {
+            const event = await mockData.getApiGateWayRoute('', '', 'PATCH');
+            const error = new Error();
+
+            this.router = new Router({
+                event,
+                basePath: 'unittest/v1',
+                handlerPath: 'test/apigateway/',
+                schemaPath: 'test/openapi.yml',
+                beforeAll: () => {
+                    throw error;
+                },
+                onError: (req, res) => {
+                    res.code = 400;
+                }
+            });
+            const response = await this.router.route();
+            assert.equal(400, response.statusCode);
+
+        });
     });
 });

--- a/test/apigateway/router.test.js
+++ b/test/apigateway/router.test.js
@@ -178,7 +178,7 @@ describe('Test Router', () => {
         it('should return status code that was set in onError callback', async () => {
             const event = await mockData.getApiGateWayRoute('', '', 'PATCH');
             const error = new Error();
-
+            const returnedCode = 400;
             this.router = new Router({
                 event,
                 basePath: 'unittest/v1',
@@ -188,11 +188,11 @@ describe('Test Router', () => {
                     throw error;
                 },
                 onError: (req, res) => {
-                    res.code = 400;
+                    res.code = returnedCode;
                 }
             });
             const response = await this.router.route();
-            assert.equal(400, response.statusCode);
+            assert.equal(returnedCode, response.statusCode);
 
         });
     });


### PR DESCRIPTION
it makes sense to pass `this._error` to `_handleError` instead of `response`, because in case of an error, we return `this._error.response`, not `response.response`.

e.g. we can change status code in `onError` callback and we have to get this status in returned response

        onError: (req, res, error) => {
            setEpsagonError(error);
            if (error instanceof InternalError) {
                res.code = error.code;
                res.setError(error.key, error.message);
            }
        },