### PR TITLE
Split router.js file and add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@types/aws-lambda": "^8.10.93",
                 "chai": "^4.2.0",
                 "chai-as-promised": "^7.1.1",
+                "cross-env": "^7.0.3",
                 "eslint": "^7.7.0",
                 "eslint-config-prettier": "^6.11.0",
                 "eslint-plugin-import": "^2.22.1",
@@ -1232,6 +1233,24 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {
@@ -6109,6 +6128,15 @@
         "core-js-pure": {
             "version": "3.6.5",
             "dev": true
+        },
+        "cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            }
         },
         "cross-spawn": {
             "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "@types/aws-lambda": "^8.10.93",
                 "chai": "^4.2.0",
                 "chai-as-promised": "^7.1.1",
-                "cross-env": "^7.0.3",
                 "eslint": "^7.7.0",
                 "eslint-config-prettier": "^6.11.0",
                 "eslint-plugin-import": "^2.22.1",
@@ -1233,24 +1232,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.1"
-            },
-            "bin": {
-                "cross-env": "src/bin/cross-env.js",
-                "cross-env-shell": "src/bin/cross-env-shell.js"
-            },
-            "engines": {
-                "node": ">=10.14",
-                "npm": ">=6",
-                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {
@@ -6128,15 +6109,6 @@
         "core-js-pure": {
             "version": "3.6.5",
             "dev": true
-        },
-        "cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^7.0.1"
-            }
         },
         "cross-spawn": {
             "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@types/aws-lambda": "^8.10.93",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
+        "cross-env": "^7.0.3",
         "eslint": "^7.7.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
             "es6": true
         },
         "parserOptions": {
-            "ecmaVersion": 2020
+            "ecmaVersion": 2021
         },
         "plugins": [
             "prettier"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "@types/aws-lambda": "^8.10.93",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
-        "cross-env": "^7.0.3",
         "eslint": "^7.7.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-import": "^2.22.1",

--- a/src/apigateway/endpoint-config/enpoint-config.js
+++ b/src/apigateway/endpoint-config/enpoint-config.js
@@ -1,0 +1,44 @@
+const FileConfigReader = require('./file-config-reader');
+const NotFoundModuleError = require('./not-found-module-error');
+
+class EndpointConfig {
+    constructor({requirements = {}, ...methods} = {}) {
+        this._requirements = requirements;
+        this._methods = methods;
+    }
+
+    ifExist() {
+        return Object.keys(this._methods).length > 0;
+    }
+
+    getRequirementsByMethodName(methodName) {
+        return this._requirements[methodName];
+    }
+
+    getHandlerByMethodName(methodName) {
+        return this._methods[methodName];
+    }
+
+    ifMethodExist(methodName) {
+        const method = this.getHandlerByMethodName(methodName);
+        return method && typeof method === 'function';
+    }
+
+    static fromEmptyConfig() {
+        return new EndpointConfig();
+    }
+
+    static fromFilePath({modulePath, ConfigReader = FileConfigReader}) {
+        const fileReader = new ConfigReader({modulePath});
+        try {
+            return new EndpointConfig(fileReader.read());
+        } catch (e) {
+            if (e instanceof NotFoundModuleError) {
+                return EndpointConfig.fromEmptyConfig();
+            }
+            throw e;
+        }
+    }
+}
+
+module.exports = EndpointConfig;

--- a/src/apigateway/endpoint-config/file-config-reader.js
+++ b/src/apigateway/endpoint-config/file-config-reader.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const NotFoundModuleError = require('./not-found-module-error');
+
+class FileConfigReader {
+    constructor({modulePath, requirer = require}) {
+        this._requirer = requirer;
+        this._modulePath = modulePath;
+        const finalPath = path.join(process.cwd(), modulePath);
+        this._finalPath = finalPath;
+        this._checkIfModuleExist();
+    }
+
+    read() {
+        return this._requirer(this._finalPath);
+    }
+
+    _checkIfModuleExist() {
+        try {
+            this._requirer.resolve(this._finalPath);
+        } catch (e) {
+            throw new NotFoundModuleError(`can't resolve module ${this._modulePath}`);
+        }
+    }
+}
+
+module.exports = FileConfigReader;

--- a/src/apigateway/endpoint-config/index.js
+++ b/src/apigateway/endpoint-config/index.js
@@ -1,0 +1,3 @@
+const EndpointConfig = require('./enpoint-config');
+
+module.exports = EndpointConfig;

--- a/src/apigateway/endpoint-config/not-found-module-error.js
+++ b/src/apigateway/endpoint-config/not-found-module-error.js
@@ -1,0 +1,13 @@
+class NotFoundModuleError extends Error {
+    constructor(message) {
+        super(message);
+        // Ensure the name of this error is the same as the class name
+        this.name = this.constructor.name;
+        // This clips the constructor invocation from the stack trace.
+        // It's not absolutely essential, but it does make the stack trace a little nicer.
+        //  @see Node.js reference (bottom)
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+module.exports = NotFoundModuleError;

--- a/src/apigateway/endpoint-config/not-matched-url-error.js
+++ b/src/apigateway/endpoint-config/not-matched-url-error.js
@@ -1,0 +1,13 @@
+class NotMatchedUrlError extends Error {
+    constructor(message) {
+        super(message);
+        // Ensure the name of this error is the same as the class name
+        this.name = this.constructor.name;
+        // This clips the constructor invocation from the stack trace.
+        // It's not absolutely essential, but it does make the stack trace a little nicer.
+        //  @see Node.js reference (bottom)
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+module.exports = NotMatchedUrlError;

--- a/src/apigateway/endpoint-config/path-resolver.js
+++ b/src/apigateway/endpoint-config/path-resolver.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const NotMatchedUrlError = require('./not-matched-url-error');
+
+class PathResolver {
+    constructor({basePath = '', requestPath = '', handlerPath = ''} = {}) {
+        this._setPath(basePath, requestPath, handlerPath);
+    }
+
+    _setPath(basePath, requestPath, handlerPath) {
+        const cleanBasePath = this._cleanUpPath(basePath);
+        const cleanRequestPath = this._cleanUpPath(requestPath);
+
+        if (!cleanRequestPath.startsWith(cleanBasePath)) {
+            throw new NotMatchedUrlError('base path is not match request path');
+        }
+        const urlPath = path.relative(cleanBasePath, cleanRequestPath);
+        this._path = path.join(this._cleanUpPath(handlerPath), urlPath);
+    }
+
+    get path() {
+        return this._path;
+    }
+
+    _cleanUpPath(dirtyPath) {
+        if (dirtyPath.startsWith('/')) {
+            dirtyPath = dirtyPath.substr(1);
+        }
+        if (dirtyPath.endsWith('/')) {
+            dirtyPath = dirtyPath.slice(0, -1);
+        }
+        return dirtyPath;
+    }
+}
+
+module.exports = PathResolver;

--- a/src/apigateway/http-errors/method-not-exist-error.js
+++ b/src/apigateway/http-errors/method-not-exist-error.js
@@ -1,0 +1,20 @@
+const ResponseClient = require('../response-client');
+
+class MethodNotExistError {
+    constructor() {
+        this._setResponseClient();
+    }
+
+    _setResponseClient() {
+        const responseClient = new ResponseClient();
+        responseClient.code = 403;
+        responseClient.setError('method', 'method not allowed');
+        this._responseClient = responseClient;
+    }
+
+    get response() {
+        return this._responseClient.response;
+    }
+}
+
+module.exports = MethodNotExistError;

--- a/src/apigateway/http-errors/not-found-error.js
+++ b/src/apigateway/http-errors/not-found-error.js
@@ -1,0 +1,16 @@
+const ResponseClient = require('../response-client');
+
+class NotFoundError {
+    constructor() {
+        const responseClient = new ResponseClient();
+        responseClient.code = 404;
+        responseClient.setError('url', 'endpoint not found');
+        this._responseClient = responseClient;
+    }
+
+    get response() {
+        return this._responseClient.response;
+    }
+}
+
+module.exports = NotFoundError;

--- a/src/apigateway/http-errors/unknown-error.js
+++ b/src/apigateway/http-errors/unknown-error.js
@@ -1,0 +1,16 @@
+const ResponseClient = require('../response-client');
+
+class UnknownError {
+    constructor() {
+        const responseClient = new ResponseClient();
+        responseClient.code = 500;
+        responseClient.setError('server', 'internal server error');
+        this._responseClient = responseClient;
+    }
+
+    get response() {
+        return this._responseClient.response;
+    }
+}
+
+module.exports = UnknownError;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 module.exports = {
     apigateway: {
+        FileConfigReader: require('./apigateway/endpoint-config/file-config-reader'),
+        EndpointConfig: require('./apigateway/endpoint-config'),
         Request: require('./apigateway/request-client'),
         Response: require('./apigateway/response-client'),
         RequestValidator: require('./apigateway/request-validator'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,9 @@
 module.exports = {
     apigateway: {
-        FileConfigReader: require('./apigateway/endpoint-config/file-config-reader'),
-        EndpointConfig: require('./apigateway/endpoint-config'),
         Request: require('./apigateway/request-client'),
         Response: require('./apigateway/response-client'),
         RequestValidator: require('./apigateway/request-validator'),
         ResponseValidator: require('./apigateway/response-validator'),
-        Schema: require('./apigateway/schema'),
         Router: require('./apigateway/router')
     },
     dynamodb: {

--- a/test/apigateway/endpoint-config/enpoint-config.test.js
+++ b/test/apigateway/endpoint-config/enpoint-config.test.js
@@ -1,0 +1,77 @@
+const {assert, expect} = require('chai');
+const sinon = require('sinon');
+const NotFoundModuleError = require('../../../src/apigateway/endpoint-config/not-found-module-error');
+const EndpointConfig = require('../../../src').apigateway.EndpointConfig;
+
+describe('Test EndpointConfig', () => {
+    it('should create with empty constructor', () => {
+        const endpointConfig = new EndpointConfig();
+        assert.isObject(endpointConfig);
+    });
+
+    it('should create with fromEmptyConfig static method', () => {
+        const endpointConfig = new EndpointConfig();
+        assert.deepEqual(endpointConfig, EndpointConfig.fromEmptyConfig());
+    });
+
+    it('should return requirements for the appropriate method', () => {
+        const requirements = {get: {foo: 'bar'}};
+        const endpointConfig = new EndpointConfig({requirements});
+        assert.deepEqual(endpointConfig.getRequirementsByMethodName('get'), requirements.get);
+    });
+
+    it('should return undefined if requirements are not setup', () => {
+        const requirements = {get: {foo: 'bar'}};
+        const endpointConfig = new EndpointConfig({requirements});
+        assert.isUndefined(endpointConfig.getRequirementsByMethodName('post'), undefined);
+
+    });
+
+    it('should return appropriate method handler if exist', () => {
+        const get = Symbol('get'); // using Symbol to check if it is the same link
+        const endpointConfig = new EndpointConfig({get});
+        expect(get).to.eq(endpointConfig.getHandlerByMethodName('get'));
+    });
+
+    describe('EndpointConfig.fromFilePath', () => {
+        it('should read config from file', () => {
+            const readFn = sinon.fake();
+            const constructorFn = sinon.fake();
+
+            class ConfigReader {
+                constructor(props) {
+                    constructorFn(props);
+                }
+
+                read = readFn;
+            }
+
+            const modulePath = 'random/path/string';
+            EndpointConfig.fromFilePath({modulePath, ConfigReader});
+            expect(readFn.callCount).to.eq(1);
+            expect(readFn.getCall(0).args).to.deep.eq([]);
+            expect(constructorFn.getCall(0).args).to.deep.eq([{modulePath}]);
+        });
+
+        it('should return empty config if error occurs while reading configuration file', () => {
+            class ConfigReader {
+                read = () => {throw new NotFoundModuleError('module not found')};
+            }
+            const modulePath = 'random/path/string';
+            const config = EndpointConfig.fromFilePath({modulePath, ConfigReader})
+            expect(config.getRequirementsByMethodName('get')).to.be.undefined;
+            expect(config.getRequirementsByMethodName('patch')).to.be.undefined;
+        });
+
+        it('should rethrow the same error if error occurs', () => {
+            const error = new Error('random error');
+            class ConfigReader {
+                read = () => {
+                    throw error;
+                }
+            }
+            const modulePath = 'random/path/string';
+            expect(() => EndpointConfig.fromFilePath({modulePath, ConfigReader})).to.throw('random error');
+        });
+    });
+});

--- a/test/apigateway/endpoint-config/enpoint-config.test.js
+++ b/test/apigateway/endpoint-config/enpoint-config.test.js
@@ -1,7 +1,7 @@
 const {assert, expect} = require('chai');
 const sinon = require('sinon');
 const NotFoundModuleError = require('../../../src/apigateway/endpoint-config/not-found-module-error');
-const EndpointConfig = require('../../../src').apigateway.EndpointConfig;
+const EndpointConfig = require('../../../src/apigateway/endpoint-config');
 
 describe('Test EndpointConfig', () => {
     it('should create with empty constructor', () => {

--- a/test/apigateway/endpoint-config/file-config-reader.test.js
+++ b/test/apigateway/endpoint-config/file-config-reader.test.js
@@ -1,7 +1,8 @@
 const path = require('path');
-const FileConfigReader = require('../../../src').apigateway.FileConfigReader;
-const { assert } = require('chai');
+const {assert} = require('chai');
+
 const randomModule = require('./mocks/random-dir-name');
+const FileConfigReader = require('../../../src/apigateway/endpoint-config/file-config-reader');
 
 describe('FileConfigReader', () => {
     it('should read config file from folder without index.js', () => {
@@ -17,7 +18,7 @@ describe('FileConfigReader', () => {
     });
 
     it('should fail if path not found', () => {
-        const modulePath = path.join('random', 'module', 'name')
-        assert.throws(() => new FileConfigReader({modulePath}), 'can\'t resolve module random/module/name');
+        const modulePath = path.join('random', 'module', 'name');
+        assert.throws(() => new FileConfigReader({modulePath}), "can't resolve module random/module/name");
     });
 });

--- a/test/apigateway/endpoint-config/file-config-reader.test.js
+++ b/test/apigateway/endpoint-config/file-config-reader.test.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const FileConfigReader = require('../../../src').apigateway.FileConfigReader;
+const { assert } = require('chai');
+const randomModule = require('./mocks/random-dir-name');
+
+describe('FileConfigReader', () => {
+    it('should read config file from folder without index.js', () => {
+        const modulePath = 'test/apigateway/endpoint-config/mocks/random-dir-name';
+        const fileConfigReader = new FileConfigReader({modulePath});
+        assert.deepEqual(fileConfigReader.read().requirements, randomModule.requirements);
+    });
+
+    it('should read config file from folder with index.js', () => {
+        const modulePath = 'test/apigateway/endpoint-config/mocks/random-dir-name/index.js';
+        const fileConfigReader = new FileConfigReader({modulePath});
+        assert.deepEqual(fileConfigReader.read().requirements, randomModule.requirements);
+    });
+
+    it('should fail if path not found', () => {
+        const modulePath = path.join('random', 'module', 'name')
+        assert.throws(() => new FileConfigReader({modulePath}), 'can\'t resolve module random/module/name');
+    });
+});

--- a/test/apigateway/endpoint-config/mocks/random-dir-name/index.js
+++ b/test/apigateway/endpoint-config/mocks/random-dir-name/index.js
@@ -1,0 +1,11 @@
+const requirements = {
+    get: 'get'
+};
+const get = () => {
+    return 'get';
+};
+
+module.exports = {
+    get,
+    requirements
+};

--- a/test/apigateway/endpoint-config/path-resolver.test.js
+++ b/test/apigateway/endpoint-config/path-resolver.test.js
@@ -1,0 +1,49 @@
+const PathResolver = require('../../../src/apigateway/endpoint-config/path-resolver');
+const path = require('path');
+const {expect} = require('chai');
+
+describe('PathResolver', () => {
+    it('PathResolver should be created', () => {
+        const pathResolver = new PathResolver();
+        expect(pathResolver.path).to.eq('.')
+    });
+
+    it('Path resolver should resolve simple cases', () => {
+        const basePath = '/';
+        const handlerPath = '/hello';
+        const requestPath = '/world';
+
+        const pathResolver = new PathResolver({
+            basePath,
+            handlerPath,
+            requestPath,
+        });
+        expect(pathResolver.path).to.eq(path.join('hello', 'world'));
+    });
+
+    it('Path resolver should throw error if paths don\'t match', () => {
+        const basePath = '/foo';
+        const handlerPath = '/hello';
+        const requestPath = '/world';
+
+        const handler = () => new PathResolver({
+            basePath,
+            handlerPath,
+            requestPath,
+        });
+        expect(handler).to.throw('base path is not match request path');
+    });
+
+    it('Path resolver should clean /', () => {
+        const basePath = '/foo';
+        const handlerPath = '/hello/';
+        const requestPath = '/foo/world/';
+
+        const pathResolver = new PathResolver({
+            basePath,
+            handlerPath,
+            requestPath,
+        });
+        expect(pathResolver.path).to.eq(path.join('hello', 'world'));
+    });
+});

--- a/test/apigateway/request-validator.test.js
+++ b/test/apigateway/request-validator.test.js
@@ -2,7 +2,7 @@ const {assert} = require('chai');
 const RequestClient = require('../../src').apigateway.Request;
 const ResponseClient = require('../../src').apigateway.Response;
 const RequestValidator = require('../../src').apigateway.RequestValidator;
-const Schema = require('../../src').apigateway.Schema;
+const Schema = require('../../src/apigateway/schema');
 const mockData = require('./mock-data');
 
 describe('Test RequestValidator', () => {
@@ -135,7 +135,7 @@ describe('Test RequestValidator', () => {
     it('valid json: complex schema with allOfs', async () => {
         const eventClient2 = new RequestClient(mockData.getBodyDataWithComplexObject());
         const responseClient2 = new ResponseClient();
-        const schema = Schema.fromFilePath('test/openapi.yml')
+        const schema = Schema.fromFilePath('test/openapi.yml');
         const requestValidator2 = new RequestValidator(eventClient2, responseClient2, schema);
         responseClient2._body = {};
         await requestValidator2._validateRequest(
@@ -150,7 +150,7 @@ describe('Test RequestValidator', () => {
     it('invalid json: complex schema with allOfs', async () => {
         const eventClient2 = new RequestClient(mockData.getBodyDataWithInvalidComplexObject());
         const responseClient2 = new ResponseClient();
-        const schema = Schema.fromFilePath('test/openapi.yml')
+        const schema = Schema.fromFilePath('test/openapi.yml');
         const requestValidator2 = new RequestValidator(eventClient2, responseClient2, schema);
         responseClient2._body = {};
         await requestValidator2._validateRequest(

--- a/test/apigateway/response-validator.test.js
+++ b/test/apigateway/response-validator.test.js
@@ -4,7 +4,7 @@ const chaiAsPromised = require('chai-as-promised');
 const RequestClient = require('../../src').apigateway.Request;
 const ResponseClient = require('../../src').apigateway.Response;
 const ResponseValidator = require('../../src').apigateway.ResponseValidator;
-const Schema = require('../../src').apigateway.Schema;
+const Schema = require('../../src/apigateway/schema');
 const mockData = require('./mock-data');
 
 use(chaiAsPromised);

--- a/test/apigateway/router.test.js
+++ b/test/apigateway/router.test.js
@@ -7,8 +7,8 @@ const mockPermissions = require('./mock-permissions-middleware');
 describe('Test Router', () => {
     let event;
     beforeEach(() => {
-        event = { httpMethod: 'get', requestContext: {}};
-    })
+        event = {httpMethod: 'get', requestContext: {}};
+    });
     describe('test route', () => {
         it('router: found app route', async () => {
             this.router = new Router({
@@ -198,175 +198,188 @@ describe('Test Router', () => {
             });
             const response = await this.router.route();
             assert.equal(returnedCode, response.statusCode);
-
         });
         it('should return 404 error if config is not exist', async () => {
             class Config {
-                ifExist(){
+                ifExist() {
                     return false;
                 }
-                static fromFilePath = () => {
+                static fromFilePath() {
                     return new Config();
                 }
             }
-            const router = new Router({
-                event,
-            }, {Config});
-            const result = await router.route()
+            const router = new Router(
+                {
+                    event
+                },
+                {Config}
+            );
+            const result = await router.route();
             expect(result.statusCode).to.be.eq(404);
-        })
-
+        });
 
         it('should return 403 error if config is exist and method is not exist', async () => {
             class Config {
-                ifExist(){
+                ifExist() {
                     return true;
                 }
 
-                ifMethodExist(){
+                ifMethodExist() {
                     return false;
                 }
 
-                static fromFilePath = () => {
+                static fromFilePath() {
                     return new Config();
                 }
             }
-            const router = new Router({
-                event,
-            }, {Config});
-            const result = await router.route()
+            const router = new Router(
+                {
+                    event
+                },
+                {Config}
+            );
+            const result = await router.route();
             expect(result.statusCode).to.be.eq(403);
-        })
+        });
 
         it('should return 500 error if handler throws something', async () => {
             class Config {
-                ifExist(){
+                ifExist() {
                     return true;
                 }
 
-                ifMethodExist(){
+                ifMethodExist() {
                     return true;
                 }
 
-                getRequirementsByMethodName(){
+                getRequirementsByMethodName() {
                     return {};
                 }
 
-                getHandlerByMethodName(){
+                getHandlerByMethodName() {
                     return () => {
-                        throw new Error()
-                    }
+                        throw new Error();
+                    };
                 }
 
-                static fromFilePath = () => {
+                static fromFilePath() {
                     return new Config();
                 }
-
             }
 
             class PathResolverMock {
-                path = '$$$randomString'
+                constructor() {
+                    this.path = '$$$randomString';
+                }
             }
 
-
-            const router = new Router({
-                event,
-            }, {Config, PathResolverMock});
-            const result = await router.route()
+            const router = new Router(
+                {
+                    event
+                },
+                {Config, PathResolverMock}
+            );
+            const result = await router.route();
             expect(result.statusCode).to.be.eq(500);
-        })
+        });
 
         it('should call afterAll callback', async () => {
             class Config {
-                ifExist(){
+                ifExist() {
                     return true;
                 }
 
-                ifMethodExist(){
+                ifMethodExist() {
                     return true;
                 }
 
-                getRequirementsByMethodName(){
+                getRequirementsByMethodName() {
                     return {};
                 }
 
-                getHandlerByMethodName(){
+                getHandlerByMethodName() {
                     return () => () => ({
                         response: {}
-                    })
+                    });
                 }
 
-                static fromFilePath = () => {
+                static fromFilePath() {
                     return new Config();
                 }
-
             }
 
             class PathResolverMock {
-                path = '$$$randomString'
+                constructor() {
+                    this.path = '$$$randomString';
+                }
             }
 
             const afterAll = sinon.fake();
 
-            const router = new Router({
-                event,
-                afterAll,
-            }, {Config, PathResolverMock});
+            const router = new Router(
+                {
+                    event,
+                    afterAll
+                },
+                {Config, PathResolverMock}
+            );
 
-
-            await router.route()
+            await router.route();
             expect(afterAll.getCalls().length).to.be.eq(1);
-        })
+        });
         it('should validate response', async () => {
             class Config {
-                ifExist(){
+                ifExist() {
                     return true;
                 }
 
-                ifMethodExist(){
+                ifMethodExist() {
                     return true;
                 }
 
-                getRequirementsByMethodName(){
+                getRequirementsByMethodName() {
                     return {
                         responseBody: '$$fakeName'
                     };
                 }
 
-                getHandlerByMethodName(){
+                getHandlerByMethodName() {
                     return () => () => ({
                         response: {}
-                    })
+                    });
                 }
 
-                static fromFilePath = () => {
+                static fromFilePath() {
                     return new Config();
                 }
-
             }
 
             class PathResolverMock {
-                path = '$$$randomString'
+                constructor() {
+                    this.path = '$$$randomString';
+                }
             }
 
-            const isValid = sinon.fake(() => Promise.resolve())
-
+            const isValid = sinon.fake(() => Promise.resolve());
 
             class ResponseValidatorMock {
-                isValid = isValid
+                constructor() {
+                    this.isValid = isValid;
+                }
             }
 
+            const router = new Router(
+                {
+                    event
+                },
+                {
+                    Config,
+                    PathResolver: PathResolverMock,
+                    ResponseValidator: ResponseValidatorMock
+                }
+            );
 
-            const router = new Router({
-                event,
-            }, {
-                Config,
-                PathResolver: PathResolverMock,
-                ResponseValidator: ResponseValidatorMock
-            });
-
-
-            await router.route()
+            await router.route();
             expect(isValid.getCalls().length).to.be.eq(1);
         });
     });

--- a/test/apigateway/router.test.js
+++ b/test/apigateway/router.test.js
@@ -5,6 +5,10 @@ const mockData = require('./mock-data');
 const mockPermissions = require('./mock-permissions-middleware');
 
 describe('Test Router', () => {
+    let event;
+    beforeEach(() => {
+        event = { httpMethod: 'get', requestContext: {}};
+    })
     describe('test route', () => {
         it('router: found app route', async () => {
             this.router = new Router({
@@ -95,10 +99,10 @@ describe('Test Router', () => {
             this.router = new Router({
                 event: await mockData.getIndexApiGateWayRoute(),
                 basePath: 'unittest/v1',
-                handlerPath: '/test/apigateway'
+                handlerPath: '/test/apigateway/mocks'
             });
-            const results = await this.router._getEndpoint();
-            assert.equal(results, 'test/apigateway/index.js');
+            const result = await this.router.route();
+            assert.equal(result.statusCode, 404);
         });
         it('router: ran route without the need of requirements export', async () => {
             this.router = new Router({
@@ -174,6 +178,196 @@ describe('Test Router', () => {
             assert.deepEqual(spyFn.callCount, 1);
             assert.deepEqual(spyFn.getCall(0).args[2], error);
             assert.equal(spyFn.getCall(0).args[1].code, response.statusCode);
+        });
+        it('should return status code that was set in onError callback', async () => {
+            const event = await mockData.getApiGateWayRoute('', '', 'PATCH');
+            const error = new Error();
+            const returnedCode = 400;
+            this.router = new Router({
+                event,
+                basePath: 'unittest/v1',
+                handlerPath: 'test/apigateway/',
+                schemaPath: 'test/openapi.yml',
+                beforeAll: () => {
+                    throw error;
+                },
+                onError: (req, res) => {
+                    res.code = returnedCode;
+                    return res;
+                }
+            });
+            const response = await this.router.route();
+            assert.equal(returnedCode, response.statusCode);
+
+        });
+        it('should return 404 error if config is not exist', async () => {
+            class Config {
+                ifExist(){
+                    return false;
+                }
+                static fromFilePath = () => {
+                    return new Config();
+                }
+            }
+            const router = new Router({
+                event,
+            }, {Config});
+            const result = await router.route()
+            expect(result.statusCode).to.be.eq(404);
+        })
+
+
+        it('should return 403 error if config is exist and method is not exist', async () => {
+            class Config {
+                ifExist(){
+                    return true;
+                }
+
+                ifMethodExist(){
+                    return false;
+                }
+
+                static fromFilePath = () => {
+                    return new Config();
+                }
+            }
+            const router = new Router({
+                event,
+            }, {Config});
+            const result = await router.route()
+            expect(result.statusCode).to.be.eq(403);
+        })
+
+        it('should return 500 error if handler throws something', async () => {
+            class Config {
+                ifExist(){
+                    return true;
+                }
+
+                ifMethodExist(){
+                    return true;
+                }
+
+                getRequirementsByMethodName(){
+                    return {};
+                }
+
+                getHandlerByMethodName(){
+                    return () => {
+                        throw new Error()
+                    }
+                }
+
+                static fromFilePath = () => {
+                    return new Config();
+                }
+
+            }
+
+            class PathResolverMock {
+                path = '$$$randomString'
+            }
+
+
+            const router = new Router({
+                event,
+            }, {Config, PathResolverMock});
+            const result = await router.route()
+            expect(result.statusCode).to.be.eq(500);
+        })
+
+        it('should call afterAll callback', async () => {
+            class Config {
+                ifExist(){
+                    return true;
+                }
+
+                ifMethodExist(){
+                    return true;
+                }
+
+                getRequirementsByMethodName(){
+                    return {};
+                }
+
+                getHandlerByMethodName(){
+                    return () => () => ({
+                        response: {}
+                    })
+                }
+
+                static fromFilePath = () => {
+                    return new Config();
+                }
+
+            }
+
+            class PathResolverMock {
+                path = '$$$randomString'
+            }
+
+            const afterAll = sinon.fake();
+
+            const router = new Router({
+                event,
+                afterAll,
+            }, {Config, PathResolverMock});
+
+
+            await router.route()
+            expect(afterAll.getCalls().length).to.be.eq(1);
+        })
+        it('should validate response', async () => {
+            class Config {
+                ifExist(){
+                    return true;
+                }
+
+                ifMethodExist(){
+                    return true;
+                }
+
+                getRequirementsByMethodName(){
+                    return {
+                        responseBody: '$$fakeName'
+                    };
+                }
+
+                getHandlerByMethodName(){
+                    return () => () => ({
+                        response: {}
+                    })
+                }
+
+                static fromFilePath = () => {
+                    return new Config();
+                }
+
+            }
+
+            class PathResolverMock {
+                path = '$$$randomString'
+            }
+
+            const isValid = sinon.fake(() => Promise.resolve())
+
+
+            class ResponseValidatorMock {
+                isValid = isValid
+            }
+
+
+            const router = new Router({
+                event,
+            }, {
+                Config,
+                PathResolver: PathResolverMock,
+                ResponseValidator: ResponseValidatorMock
+            });
+
+
+            await router.route()
+            expect(isValid.getCalls().length).to.be.eq(1);
         });
     });
 });


### PR DESCRIPTION
It looks like that router.js file is not follow single responsibility principle and additionaly it is too complex becase there are several layers of abstractions (working with paths, modules, file system etc). This request is attempt to make router.js more clean and understandable. I've try to cover it with the automatic tests. 

The piece of code illustrates that we have some issues related to readability and maintainability, because method with the name _getControllerPath is not in the class.
```
        ....
        if (await this._isDirectory(possiblePath)) {
           //
           //  _getControllerPath is not defined in class
           //
            path = await this._getControllerPath(possiblePath, files, index + 1);
        } else if (await this._isFile(`${possiblePath}.js`)) {
            path = `${possiblePath}.js`;
           .....

```